### PR TITLE
Separate definitions from execution

### DIFF
--- a/fortik.py
+++ b/fortik.py
@@ -73,10 +73,19 @@ tokens = '''
 [ to a ] is drop
 [ to b to a  b a ] is swap
 [ 0 swap - ] is neg
-[ to c to b to a  b b * 4 a c * * - ] is D  5 neg 4 neg 1 D .
-[ to n  n 2 < [ 1 ] [ n n 1 - fact * ] ifelse ] is fact  5 fact .
+[ to c to b to a  b b * 4 a c * * - ] is D
+
+5 neg 4 neg 1 D .
+
+[ to n  n 2 < [ 1 ] [ n n 1 - fact * ] ifelse ] is fact
+
+5 fact .
+
 [ to n  n [ n 1 - odd ] [ 1 ] ifelse ] is even
-[ to n  n [ n 1 - even ] [ 0 ] ifelse ] is odd  42 dup even . odd .
+[ to n  n [ n 1 - even ] [ 0 ] ifelse ] is odd
+
+42 dup even . odd .
+
 '''.split()
 
 repl(execute({}, [], parse(tokens)), [])


### PR DESCRIPTION
Make executed code more visible by putting it aside from the word definitions.